### PR TITLE
Fix underscore replacement in AI task log

### DIFF
--- a/lib/projects.ts
+++ b/lib/projects.ts
@@ -230,7 +230,7 @@ export async function simulateAITask(projectId: string, taskType: string = 'cont
         projectId,
         user.id,
         'ai_task_started',
-        `Started AI ${taskType.replace('_', ' ')}`
+        `Started AI ${taskType.replace(/_/g, ' ')}`
       )
     }
     


### PR DESCRIPTION
## Summary
- ensure all underscores are replaced when logging the AI task type

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68408dfd4d308330943cc9b17c6e55a0